### PR TITLE
Fix ParameterExtractor.BACKWARD_TASK to use previous_answer instead of previous_code

### DIFF
--- a/experts/parameter_extractor.py
+++ b/experts/parameter_extractor.py
@@ -23,7 +23,7 @@ The original problem is as follow:
 {problem_description}
 
 The code you give previously is as follow:
-{previous_code}
+{previous_answer}
     
 The feedback is as follow:
 {feedback}


### PR DESCRIPTION
Originally, `{previous_code}` is used:

https://github.com/xzymustbexzy/Chain-of-Experts/blob/9d96bcc2f067177eb0e122b1aae8227748dc6830/experts/parameter_extractor.py#L25-L26

while `previous_answer` is passed in `ParameterExtractor.backward`:

https://github.com/xzymustbexzy/Chain-of-Experts/blob/9d96bcc2f067177eb0e122b1aae8227748dc6830/experts/parameter_extractor.py#L79-L82

This mismatch causes a runtime error in `ParameterExtractor.backward`.