### PR TITLE
Experts should produce refined_result instead of refined_code

### DIFF
--- a/experts/code_reviewer.py
+++ b/experts/code_reviewer.py
@@ -28,7 +28,7 @@ The output format is a JSON structure followed by refined code:
 {{
     'is_caused_by_you': false,
     'reason': 'leave empty string if the problem is not caused by you',
-    'refined_code': 'Your refined answer...'
+    'refined_result': 'Your refined answer...'
 }}
 '''
 

--- a/experts/modeling_knowledge_supplement_expert.py
+++ b/experts/modeling_knowledge_supplement_expert.py
@@ -32,7 +32,7 @@ The output format is a JSON structure followed by refined code:
 {{
     'is_caused_by_you': false,
     'reason': 'leave empty string if the problem is not caused by you',
-    'refined_code': 'Your refined code...'
+    'refined_result': 'Your refined code...'
 }}
 '''
 

--- a/experts/parameter_extractor.py
+++ b/experts/parameter_extractor.py
@@ -32,7 +32,7 @@ The output format is a JSON structure followed by refined code:
 {{
     'is_caused_by_you': false,
     'reason': 'leave empty string if the problem is not caused by you',
-    'refined_code': 'Your refined code...'
+    'refined_result': 'Your refined code...'
 }}
 '''
 

--- a/experts/programming_expert.py
+++ b/experts/programming_expert.py
@@ -32,7 +32,7 @@ The output format is a JSON structure followed by refined code:
 {{
     'is_caused_by_you': false,
     'reason': 'leave empty string if the problem is not caused by you',
-    'refined_code': 'Your refined code...'
+    'refined_result': 'Your refined code...'
 }}
 '''
 


### PR DESCRIPTION
Experts should produce `refined_result` instead of `refined_code` because  `refined_result`  is expected here:

https://github.com/xzymustbexzy/Chain-of-Experts/blob/9d96bcc2f067177eb0e122b1aae8227748dc6830/main.py#L77-L85