### PR TITLE
Fix backward of CodeReviewer, LPFileGenerator, and ModelingExpert

### DIFF
--- a/experts/code_reviewer.py
+++ b/experts/code_reviewer.py
@@ -68,6 +68,6 @@ The output format is a JSON structure followed by refined code:
             raise NotImplementedError('Please call foward first!')
         output = self.backward_chain.predict(
             problem_description=self.problem['description'], 
-            previous_code=self.previous_code,
+            previous_answer=self.previous_code,
             feedback=feedback_pool.get_current_comment_text())
         return output

--- a/experts/lp_file_generator.py
+++ b/experts/lp_file_generator.py
@@ -28,7 +28,7 @@ The feedback is as follow:
 {feedback}
 
 The modeling you give previously is as follow:
-{previous_modeling}
+{previous_answer}
 
 The output format is a JSON structure followed by refined code:
 {{

--- a/experts/modeling_expert.py
+++ b/experts/modeling_expert.py
@@ -32,7 +32,7 @@ The feedback is as follow:
 {feedback}
 
 The modeling you give previously is as follow:
-{previous_modeling}
+{previous_answer}
 
 The output format is a JSON structure followed by refined code:
 {{


### PR DESCRIPTION
In addition to #8, we need to fix other experts too.

* `CodeReviewer.BACKWARD_TASK` refers to `{previous_answer}` while `CodeReviewer.backward` passes `previous_code`
* `LPFileGenerator.BACKWARD_TASK` refers to `{previous_modeling}` while `LPFileGenerator.backward` passes `previous_answer`
* `ModelingExpert.BACKWARD_TASK` refers to `{previous_modeling}` while `ModelingExpert.backward` passes `previous_answer`